### PR TITLE
added fixes from audit

### DIFF
--- a/deployments.md
+++ b/deployments.md
@@ -1,32 +1,32 @@
 
 Arbitrum
 ----------
-SushiXSwapV2 -> 0xec4a1bf5738841456054bd720bedf18be2e3f8f0
-StargateAdapter -> 0x3541e8529d17396048a5068efc361b9fdad21eea
++ SushiXSwapV2 -> 0xec4a1bf5738841456054bd720bedf18be2e3f8f0
++ StargateAdapter -> 0x3541e8529d17396048a5068efc361b9fdad21eea
 
 
 Optimism
 ----------
-SushiXSwapV2 -> 0xd9d93d4daa6656b13dbc1997a0c543ac86ff2690
-StargateAdapter -> 0x4f52281a6a10db9761ceb39435f96d286f684d86
++ SushiXSwapV2 -> 0xd9d93d4daa6656b13dbc1997a0c543ac86ff2690
++ StargateAdapter -> 0x4f52281a6a10db9761ceb39435f96d286f684d86
 
 
 Mainnet
 -----------
-SushiXSwapV2 -> 0xd294d0d26ef0ff2087a35616b7aada083c53640f
-StargateAdapter -> 0x8a9f096992d4adf48c4e302b3593832785ddde01
++ SushiXSwapV2 -> 0xd294d0d26ef0ff2087a35616b7aada083c53640f
++ StargateAdapter -> 0x8a9f096992d4adf48c4e302b3593832785ddde01
 
 Polygon
 -----------
-SushiXSwapV2 -> 0xc45a496bcc9ba69ffb45303f7515739c3f6ff921
-StargateAdapter -> 0x6df3838fcefd6642ad1435a4d93ed8bf6fd772f5
++ SushiXSwapV2 -> 0xc45a496bcc9ba69ffb45303f7515739c3f6ff921
++ StargateAdapter -> 0x6df3838fcefd6642ad1435a4d93ed8bf6fd772f5
 
 Avalanche
 -----------
-SushiXSwapV2 -> 0xfec47ce995b4f3c0e42ef4d477150313a4d22211
-StargateAdapter -> 0xac8d8775dfb6de938d50aeb76972f77a1682dc85
++ SushiXSwapV2 -> 0xfec47ce995b4f3c0e42ef4d477150313a4d22211
++ StargateAdapter -> 0xac8d8775dfb6de938d50aeb76972f77a1682dc85
 
 BSC
 ------------
-SushiXSwapV2 -> 0xdd9c6c40171ea2dfc31ed00b0a58be2c8a3c7971
-StargateAdapter -> 0xa7d7fbe0b2122f7055bebfe8e5f793034339ad1f
++ SushiXSwapV2 -> 0xdd9c6c40171ea2dfc31ed00b0a58be2c8a3c7971
++ StargateAdapter -> 0xa7d7fbe0b2122f7055bebfe8e5f793034339ad1f

--- a/deployments.md
+++ b/deployments.md
@@ -1,0 +1,32 @@
+
+Arbitrum
+----------
+SushiXSwapV2 -> 0xec4a1bf5738841456054bd720bedf18be2e3f8f0
+StargateAdapter -> 0x3541e8529d17396048a5068efc361b9fdad21eea
+
+
+Optimism
+----------
+SushiXSwapV2 -> 0xd9d93d4daa6656b13dbc1997a0c543ac86ff2690
+StargateAdapter -> 0x4f52281a6a10db9761ceb39435f96d286f684d86
+
+
+Mainnet
+-----------
+SushiXSwapV2 -> 0xd294d0d26ef0ff2087a35616b7aada083c53640f
+StargateAdapter -> 0x8a9f096992d4adf48c4e302b3593832785ddde01
+
+Polygon
+-----------
+SushiXSwapV2 -> 0xc45a496bcc9ba69ffb45303f7515739c3f6ff921
+StargateAdapter -> 0x6df3838fcefd6642ad1435a4d93ed8bf6fd772f5
+
+Avalanche
+-----------
+SushiXSwapV2 -> 0xfec47ce995b4f3c0e42ef4d477150313a4d22211
+StargateAdapter -> 0xac8d8775dfb6de938d50aeb76972f77a1682dc85
+
+BSC
+------------
+SushiXSwapV2 -> 0xdd9c6c40171ea2dfc31ed00b0a58be2c8a3c7971
+StargateAdapter -> 0xa7d7fbe0b2122f7055bebfe8e5f793034339ad1f

--- a/src/SushiXSwapV2.sol
+++ b/src/SushiXSwapV2.sol
@@ -21,6 +21,8 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
     uint8 private unlocked = 1;
     uint8 private paused = 1;
 
+    error IncorrectoAmountIn();
+
     constructor(IRouteProcessor _rp, address _weth) {
         rp = _rp;
         weth = IWETH(_weth);

--- a/src/SushiXSwapV2.sol
+++ b/src/SushiXSwapV2.sol
@@ -125,6 +125,7 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
     /// @inheritdoc ISushiXSwapV2
     function bridge(
         BridgeParams calldata _bridgeParams,
+        address _refundAddress,
         bytes calldata _swapPayload,
         bytes calldata _payloadData
     )
@@ -146,7 +147,7 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
 
         ISushiXSwapV2Adapter(_bridgeParams.adapter).adapterBridge{
             value: address(this).balance
-        }(_bridgeParams.adapterData, _swapPayload, _payloadData);
+        }(_bridgeParams.adapterData, _refundAddress, _swapPayload, _payloadData);
 
         emit SushiXSwapOnSrc(
             _bridgeParams.refId,
@@ -161,6 +162,7 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
     /// @inheritdoc ISushiXSwapV2
     function swapAndBridge(
         BridgeParams calldata _bridgeParams,
+        address _refundAddress,
         bytes calldata _swapData,
         bytes calldata _swapPayload,
         bytes calldata _payloadData
@@ -177,7 +179,7 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
 
         ISushiXSwapV2Adapter(_bridgeParams.adapter).adapterBridge{
             value: address(this).balance
-        }(_bridgeParams.adapterData, _swapPayload, _payloadData);
+        }(_bridgeParams.adapterData, _refundAddress, _swapPayload, _payloadData);
 
         emit SushiXSwapOnSrc(
             _bridgeParams.refId,

--- a/src/SushiXSwapV2.sol
+++ b/src/SushiXSwapV2.sol
@@ -21,8 +21,6 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
     uint8 private unlocked = 1;
     uint8 private paused = 1;
 
-    error IncorrectoAmountIn();
-
     constructor(IRouteProcessor _rp, address _weth) {
         rp = _rp;
         weth = IWETH(_weth);
@@ -150,15 +148,6 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
         ISushiXSwapV2Adapter(_bridgeParams.adapter).adapterBridge{
             value: address(this).balance
         }(_bridgeParams.adapterData, _refundAddress, _swapPayload, _payloadData);
-
-        emit SushiXSwapOnSrc(
-            _bridgeParams.refId,
-            msg.sender,
-            _bridgeParams.adapter,
-            _bridgeParams.tokenIn,
-            _bridgeParams.amountIn,
-            _bridgeParams.to
-        );
     }
     
     /// @inheritdoc ISushiXSwapV2
@@ -182,15 +171,6 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable, Multicall {
         ISushiXSwapV2Adapter(_bridgeParams.adapter).adapterBridge{
             value: address(this).balance
         }(_bridgeParams.adapterData, _refundAddress, _swapPayload, _payloadData);
-
-        emit SushiXSwapOnSrc(
-            _bridgeParams.refId,
-            msg.sender,
-            _bridgeParams.adapter,
-            _bridgeParams.tokenIn,
-            _bridgeParams.amountIn,
-            _bridgeParams.to
-        );
     }
 
     /// @notice Rescue tokens from the contract

--- a/src/adapters/CCTPAdapter.sol
+++ b/src/adapters/CCTPAdapter.sol
@@ -31,6 +31,7 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
     }
 
     error NoUSDCToBridge();
+    error NotUSDC();
 
     constructor(
         address _axelarGateway,
@@ -58,6 +59,8 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         address _token,
         bytes calldata _payloadData
     ) external payable override {
+        if (_token != address(nativeUSDC)) revert NotUSDC();
+
         IRouteProcessor.RouteProcessorData memory rpd = abi.decode(
             _swapData,
             (IRouteProcessor.RouteProcessorData)
@@ -94,6 +97,8 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         bytes calldata _payloadData,
         address _token
     ) external payable override {
+        if (_token != address(nativeUSDC)) revert NotUSDC();
+        
         PayloadData memory pd = abi.decode(_payloadData, (PayloadData));
         nativeUSDC.safeTransfer(pd.target, _amountBridged);
         IPayloadExecutor(pd.target).onPayloadReceive{gas: pd.gasLimit}(

--- a/src/adapters/SquidAdapter.sol
+++ b/src/adapters/SquidAdapter.sol
@@ -38,6 +38,7 @@ contract SquidAdapter is ISushiXSwapV2Adapter {
     /// @inheritdoc ISushiXSwapV2Adapter
     function adapterBridge(
         bytes calldata _adapterData,
+        address,
         bytes calldata,
         bytes calldata
     ) external payable override {

--- a/src/interfaces/ISushiXSwapV2.sol
+++ b/src/interfaces/ISushiXSwapV2.sol
@@ -50,21 +50,25 @@ interface ISushiXSwapV2 {
 
     /// @notice Perform a bridge through passed adapter in _bridgeParams
     /// @param _bridgeParams The bridge data for the function call
+    /// @param _refundAddress The address to refund excess funds to
     /// @param _swapPayload The swap data payload to pass to adapter
     /// @param _payloadData The payload data to pass to adapter
     function bridge(
         BridgeParams calldata _bridgeParams,
+        address _refundAddress,
         bytes calldata _swapPayload,
         bytes calldata _payloadData
     ) external payable;
     
     /// @notice Perform a swap then bridge through passed adapter in _bridgeParams
     /// @param _bridgeParams The bridge data for the function call
+    /// @param _refundAddress The address to refund excess funds to
     /// @param _swapData The swap data to pass to RouteProcessor
     /// @param _swapPayload The swap data payload to pass to adapter
     /// @param _payloadData The payload data to pass to adapter
     function swapAndBridge(
         BridgeParams calldata _bridgeParams,
+        address _refundAddress,
         bytes calldata _swapData,
         bytes calldata _swapPayload,
         bytes calldata _payloadData

--- a/src/interfaces/ISushiXSwapV2.sol
+++ b/src/interfaces/ISushiXSwapV2.sol
@@ -19,22 +19,6 @@ interface ISushiXSwapV2 {
         bytes adapterData;
     }
 
-    /// @notice Emitted when a bridge or swapAndBridge is executed
-    /// @param refId The reference id for integrators to pass when using xswap
-    /// @param sender The address of the sender
-    /// @param adapter The address of the adapter to bridge through
-    /// @param tokenIn The address of the token to bridge or pre-bridge swap from
-    /// @param amountIn The amount of token to bridge or pre-bridge swap from
-    /// @param to The address to send the bridged or post-bridge swapped token to 
-    event SushiXSwapOnSrc(
-        bytes2 indexed refId,
-        address indexed sender,
-        address adapter,
-        address tokenIn,
-        uint256 amountIn,
-        address to
-    );
-
     /// @notice Update Adapter status to enable or disable for use
     /// @param _adapter The address of the adapter to update
     /// @param _status The status to set the adapter to

--- a/src/interfaces/ISushiXSwapV2Adapter.sol
+++ b/src/interfaces/ISushiXSwapV2Adapter.sol
@@ -48,6 +48,7 @@ interface ISushiXSwapV2Adapter {
     /// @param _payloadData The payload data to pass to pass through bridge
     function adapterBridge(
         bytes calldata _adapterData,
+        address _refundAddress,
         bytes calldata _swapDataPayload,
         bytes calldata _payloadData
     ) external payable;

--- a/test/AxelarAdapterTests/AxelarAdapterBridgeTest.t.sol
+++ b/test/AxelarAdapterTests/AxelarAdapterBridgeTest.t.sol
@@ -103,6 +103,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -142,6 +143,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -180,6 +182,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -221,6 +224,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -274,6 +278,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded_dst, // swap payload
             "" // payload data
         );
@@ -333,10 +338,11 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user
                 )
             }),
+            user, // _refundAddress
             rpd_encoded_dst, // swap payload
             "" // payload data
         );
-
+        
         assertEq(
             address(axelarAdapter).balance,
             0,
@@ -373,6 +379,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -406,6 +413,7 @@ contract AxelarAdapterBridgeTest is BaseTest {
                     user
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );

--- a/test/AxelarAdapterTests/AxelarAdapterSwapAndBridgeTest.t.sol
+++ b/test/AxelarAdapterTests/AxelarAdapterSwapAndBridgeTest.t.sol
@@ -118,6 +118,7 @@ contract AxelarAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload data
             "" // payload data
@@ -185,6 +186,7 @@ contract AxelarAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload data
             "" // payload data
@@ -249,6 +251,7 @@ contract AxelarAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload data
             "" // payload data
@@ -317,6 +320,7 @@ contract AxelarAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload data
             "" // payload data

--- a/test/CCTPAdapterTests/CCTPAdapterBridgeTest.t.sol
+++ b/test/CCTPAdapterTests/CCTPAdapterBridgeTest.t.sol
@@ -100,6 +100,7 @@ contract CCTPAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -137,6 +138,7 @@ contract CCTPAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );
@@ -188,6 +190,7 @@ contract CCTPAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded_dst, // swap payload
             "" // payload data
         );
@@ -226,6 +229,7 @@ contract CCTPAdapterBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             "", // swap payload
             "" // payload data
         );

--- a/test/CCTPAdapterTests/CCTPAdapterSwapAndBridgeTest.t.sol
+++ b/test/CCTPAdapterTests/CCTPAdapterSwapAndBridgeTest.t.sol
@@ -115,6 +115,7 @@ contract CCTPAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload
             "" // payload data
@@ -177,6 +178,7 @@ contract CCTPAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload
             "" // payload data
@@ -243,6 +245,7 @@ contract CCTPAdapterSwapAndBridgeTest is BaseTest {
                     user // to
                 )
             }),
+            user, // _refundAddress
             rpd_encoded, // swap data
             "", // swap payload
             "" // payload data

--- a/test/StargateAdapterTests/StargateAdapterBridgeTest.t.sol
+++ b/test/StargateAdapterTests/StargateAdapterBridgeTest.t.sol
@@ -143,6 +143,7 @@ contract StargateAdapterBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
+            user, // _refundAddress
             "", // _swapPayload
             "" // _payloadData
         );
@@ -262,6 +263,7 @@ contract StargateAdapterBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
+            user, // _refundAddress
             "", // _swapPayload
             "" // _payloadData
         );
@@ -382,6 +384,7 @@ contract StargateAdapterBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
+            user, // _refundAddress
             "", // _swapPayload
             "" // _payloadData
         );
@@ -502,6 +505,7 @@ contract StargateAdapterBridgeTest is BaseTest {
                         0 // gas
                     )
                 }),
+                user, // _refundAddress
                 "", // _swapPayload
                 "" // _payloadData
             );
@@ -665,6 +669,7 @@ contract StargateAdapterBridgeTest is BaseTest {
                     gasForSwap // gas
                 )
             }),
+            user, // _refundAddress
             rpd_encoded_dst, // _swapPayload
             "" // _payloadData
         );
@@ -738,6 +743,7 @@ contract StargateAdapterBridgeTest is BaseTest {
                     insufficientGasForDst // gas
                 )
             }),
+            user, // _refundAddress
             rpd_encoded_dst, // _swapPayload
             "" // _payloadData
         );

--- a/test/StargateAdapterTests/StargateAdapterSwapAndBridgeTest.t.sol
+++ b/test/StargateAdapterTests/StargateAdapterSwapAndBridgeTest.t.sol
@@ -133,7 +133,8 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
-            rpd_encoded,
+            user, // _refundAddress
+            rpd_encoded, // _swapData
             "", // _swapPayload
             "" // _payloadData
         );
@@ -205,7 +206,8 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
-            rpd_encoded,
+            user, // _refundAddress
+            rpd_encoded, // _swapData
             "", // _swapPayload
             "" // _payloadData
         );
@@ -277,7 +279,8 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
-            rpd_encoded,
+            user, // _refundAddress
+            rpd_encoded, // _swapData
             "", // _swapPayload
             "" // _payloadData
         );
@@ -292,8 +295,9 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
 
     function test_SwapFromNativeToERC20AndBridge() public {
         uint64 amount = 1 ether;
+        uint64 gasAmount = 0.1 ether;
         
-        uint256 valueToSend = uint256(amount) + 0.1 ether;
+        uint256 valueToSend = uint256(amount) + gasAmount;
         vm.deal(user, valueToSend);
 
         (uint256 gasNeeded, ) = stargateAdapter.getFee(
@@ -346,12 +350,14 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
-            rpd_encoded,
+            user, // _refundAddress
+            rpd_encoded, // _swapData
             "", // _swapPayload
             "" // _payloadData
         );
 
-        assertEq(user.balance, 0, "user should have 0 native");
+        assertGt(user.balance, 0, "user should have refund amount of native");
+        assertLt(user.balance, gasAmount, "user should not have more than gas sent of native");
         assertEq(address(sushiXswap).balance, 0, "xswap should have 0 native");
         assertEq(address(stargateAdapter).balance, 0, "stargateAdapter should have 0 native");
         assertEq(usdc.balanceOf(user), 0, "user should have 0 usdc");
@@ -418,7 +424,8 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
-            rpd_encoded,
+            user, // _refundAddress
+            rpd_encoded, // _swapData
             "", // _swapPayload
             "" // _payloadData
         );
@@ -492,7 +499,8 @@ contract StargateAdapterSwapAndBridgeTest is BaseTest {
                     0 // gas
                 )
             }),
-            rpd_encoded,
+            user, // _refundAddress
+            rpd_encoded, // _swapData
             "", // _swapPayload
             "" // _payloadData
         );


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- This PR introduces the `_refundAddress` parameter to the `adapterBridge` function in the `ISushiXSwapV2Adapter` interface and the `SushiXSwapV2` contract.
- It also adds the `_refundAddress` parameter to the `bridge` and `swapAndBridge` functions in the `SushiXSwapV2` contract.
- The `CCTPAdapter` and `AxelarAdapter` contracts have been updated to include the `_refundAddress` parameter in their respective `adapterBridge` functions.
- The `CCTPAdapter` contract now checks if the `_token` is the native USDC token before executing the bridge or swapAndBridge functions.
- The `ISushiXSwapV2` interface no longer includes the `SushiXSwapOnSrc` event.

> The following files were skipped due to too many changes: `src/interfaces/ISushiXSwapV2.sol`, `src/adapters/StargateAdapter.sol`, `test/StargateAdapterTests/StargateAdapterSwapAndBridgeTest.t.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->