### PR TITLE
Feat/forge-deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ docs/
 
 # Dotenv file
 .env
+
+# forge-deploy
+/generated
+/deployments/localhost
+/deployments/31337
+
+# forge-deploy cli binary
+/forge-deploy

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,7 @@
 [submodule "lib/axelar-gmp-sdk-solidity"]
 	path = lib/axelar-gmp-sdk-solidity
 	url = https://github.com/axelarnetwork/axelar-gmp-sdk-solidity
+[submodule "lib/forge-deploy"]
+	path = lib/forge-deploy
+	url = https://github.com/0xmasayoshi/forge-deploy
+	branch = v0.0.1

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install: init
 init:
 	git submodule update --init --recursive
 	forge install
+	cd lib/forge-deploy && cargo build --release && cp target/release/forge-deploy ../../forge-deploy
 test:
 	forge test -vv
 test-gas-report:
@@ -19,5 +20,7 @@ coverage:
 coverage-info:
 	forge coverage --report debug
 deploy:
-	forge script ./script/DeploySushiXSwapV2.s.sol --broadcast --slow --optimize --optimizer-runs 999999 --names --verify --rpc-url ${RPC_URL} --chain ${CHAIN_ID} --etherscan-api-key ${ETHERSCAN_API_KEY}
+	./forge-deploy gen-deployer
+	forge script ./script/DeploySushiXSwapV2.s.sol --broadcast --slow --optimize --optimizer-runs 999999 --names --verify --rpc-url ${RPC_URL} --chain ${CHAIN_ID} --etherscan-api-key ${ETHERSCAN_API_KEY} --private-key ${PRIVATE_KEY}
+	./forge-deploy sync
 .PHONY: test

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,11 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 
+fs_permissions = [
+	{ access = "read", path = "./deployments"},
+	{ access = "read", path = "./out"}
+]
+
 [fuzz]
 runs = 1
 

--- a/script/DeploySushiXSwapV2.s.sol
+++ b/script/DeploySushiXSwapV2.s.sol
@@ -1,38 +1,42 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.10;
 
-import "forge-std/Script.sol";
+import "forge-deploy/DeployScript.sol";
+import {DeployerFunctions, DeployOptions} from "generated/deployer/DeployerFunctions.g.sol";
+
 import "../src/SushiXSwapV2.sol";
 import "../src/adapters/StargateAdapter.sol";
-
 import "../src/interfaces/IRouteProcessor.sol";
 
-contract DeploySushiXSwapV2 is Script {
+contract DeploySushiXSwapV2 is DeployScript {
+  using DeployerFunctions for Deployer;
+
   address _owner = vm.envAddress("OWNER_ADDRESS");
   //address _operator = vm.envAddress("OPERATOR_ADDRESS");
 
-  function run() external {
+  function deploy() external returns (SushiXSwapV2) {
     uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-    vm.startBroadcast(deployerPrivateKey);
 
     // deploy sushiXswapv2
     address routeProcesser = vm.envAddress("ROUTE_PROCESSOR_ADDRESS");
     address weth = vm.envAddress("WETH_ADDRESS");
-
-    SushiXSwapV2 sushiXSwap = new SushiXSwapV2(IRouteProcessor(routeProcesser), weth);
+    SushiXSwapV2 sushiXSwap = deployer.deploy_SushiXSwapV2("SushiXSwapV2", IRouteProcessor(routeProcesser), weth);
     
     // deploy stargate adapter
     address stargateRouter = vm.envAddress("STARGATE_ROUTER_ADDRESS");
     address stargateWidget = vm.envAddress("STARGATE_WIDGET_ADDRESS");
     address sgETH = vm.envAddress("SG_ETH_ADDRESS");
-    StargateAdapter stargateAdapter = new StargateAdapter(stargateRouter, stargateWidget, sgETH, routeProcesser, weth);
+    StargateAdapter stargateAdapter = deployer.deploy_StargateAdapter("StargateAdapter", stargateRouter, stargateWidget, sgETH, routeProcesser, weth);
+
+    vm.startBroadcast(deployerPrivateKey);
 
     // attach stargate & squid adapter
     sushiXSwap.updateAdapterStatus(address(stargateAdapter), true);
 
     // transfer ownership to owner
-    // set operators
     sushiXSwap.transferOwnership(_owner);
+
+    // set operators
     //sushiXSwap.setOperator(_operator);
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a submodule for `forge-deploy` and making changes to the deployment script.

### Detailed summary:
- Added a submodule for `forge-deploy`.
- Modified the deployment script to use the `DeployScript` from `forge-deploy`.
- Updated the deployment steps in the Makefile.
- Made changes to the `DeploySushiXSwapV2` contract to use the `deployer` object from `forge-deploy`.
- Updated the `deploy` function in the `DeploySushiXSwapV2` contract to return a `SushiXSwapV2` instance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->