### PR TITLE
Revert "fix: undeflow edge case with gasleft() - reserveGas"

### DIFF
--- a/src/SushiXSwapV2.sol
+++ b/src/SushiXSwapV2.sol
@@ -148,12 +148,6 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable {
         ISushiXSwapV2Adapter(_bridgeParams.adapter).adapterBridge{
             value: address(this).balance
         }(_bridgeParams.adapterData, _refundAddress, _swapPayload, _payloadData);
-
-        emit BridgeOnSource(
-            _bridgeParams.refId,
-            msg.sender,
-            _bridgeParams.adapter
-        );
     }
     
     /// @inheritdoc ISushiXSwapV2
@@ -177,12 +171,6 @@ contract SushiXSwapV2 is ISushiXSwapV2, Ownable {
         ISushiXSwapV2Adapter(_bridgeParams.adapter).adapterBridge{
             value: address(this).balance
         }(_bridgeParams.adapterData, _refundAddress, _swapPayload, _payloadData);
-
-        emit SwapAndBridgeOnSource(
-            _bridgeParams.refId,
-            msg.sender,
-            _bridgeParams.adapter
-        );
     }
 
     /// @notice Rescue tokens from the contract

--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -158,14 +158,13 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         string memory tokenSymbol,
         uint256 amount
     ) internal override {
-        uint256 gasLeft = gasleft();
         (address to, bytes memory _swapData, bytes memory _payloadData) = abi
             .decode(payload, (address, bytes, bytes));
         address _token = gateway.tokenAddresses(tokenSymbol);
 
         uint256 reserveGas = 100000;
 
-        if (gasLeft < reserveGas) {
+        if (gasleft() < reserveGas) {
             IERC20(_token).safeTransfer(to, amount);
 
             /// @dev transfer any native token
@@ -176,7 +175,7 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         }
 
         // 100000 -> exit gas
-        uint256 limit = gasLeft - reserveGas;
+        uint256 limit = gasleft() - reserveGas;
 
         if (_swapData.length > 0) {
             try

--- a/src/adapters/CCTPAdapter.sol
+++ b/src/adapters/CCTPAdapter.sol
@@ -98,7 +98,7 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         address _token
     ) external payable override {
         if (_token != address(nativeUSDC)) revert NotUSDC();
-
+        
         PayloadData memory pd = abi.decode(_payloadData, (PayloadData));
         nativeUSDC.safeTransfer(pd.target, _amountBridged);
         IPayloadExecutor(pd.target).onPayloadReceive{gas: pd.gasLimit}(
@@ -169,7 +169,6 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         string memory /*sourceAddress*/,
         bytes calldata payload
     ) internal override {
-        uint256 gasLeft = gasleft();
         (
             address to,
             uint256 amount,
@@ -179,7 +178,7 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
 
         uint256 reserveGas = 100000;
 
-        if (gasLeft < reserveGas) {
+        if (gasleft() < reserveGas) {
             nativeUSDC.safeTransfer(to, amount);
 
             /// @dev transfer any native token
@@ -191,7 +190,7 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         }
 
         // 100000 -> exit gas
-        uint256 limit = gasLeft - reserveGas;
+        uint256 limit = gasleft() - reserveGas;
 
         if (_swapData.length > 0) {
             try

--- a/src/adapters/StargateAdapter.sol
+++ b/src/adapters/StargateAdapter.sol
@@ -212,7 +212,6 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         uint256 amountLD,
         bytes memory payload
     ) external {
-        uint256 gasLeft = gasleft();
         if (msg.sender != address(stargateRouter)) revert NotStargateRouter();
 
         (address to, bytes memory _swapData, bytes memory _payloadData) = abi
@@ -220,7 +219,7 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
 
         uint256 reserveGas = 100000;
 
-        if (gasLeft < reserveGas) {
+        if (gasleft() < reserveGas) {
             if (_token != sgeth) {
                 IERC20(_token).safeTransfer(to, amountLD);
             }
@@ -233,7 +232,7 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         }
 
         // 100000 -> exit gas
-        uint256 limit = gasLeft - reserveGas;
+        uint256 limit = gasleft() - reserveGas;
 
         if (_swapData.length > 0) {
             try

--- a/src/interfaces/ISushiXSwapV2.sol
+++ b/src/interfaces/ISushiXSwapV2.sol
@@ -18,18 +18,6 @@ interface ISushiXSwapV2 {
         bytes adapterData;
     }
 
-    event BridgeOnSource(
-        bytes2 indexed refId,
-        address indexed sender,
-        address indexed adapter
-    );
-
-    event SwapAndBridgeOnSource(
-        bytes2 indexed refId,
-        address indexed sender,
-        address indexed adapter
-    );
-
     /// @notice Update Adapter status to enable or disable for use
     /// @param _adapter The address of the adapter to update
     /// @param _status The status to set the adapter to

--- a/test/AxelarAdapterTests/AxelarAdapterExecutesTest.t.sol
+++ b/test/AxelarAdapterTests/AxelarAdapterExecutesTest.t.sol
@@ -597,69 +597,6 @@ contract AxelarAdapterExecutesTest is BaseTest {
         assertEq(weth.balanceOf(user), 0, "user should have 0 weth");
     }
 
-    function test_ReceiveUSDCAndNativeFailedSwapMinimumGasSent() public {
-        uint32 amount = 1000000; // 1 USDC
-        uint64 dustAmount = 0.2 ether;
-
-        deal(address(usdc), address(axelarAdapterHarness), amount); // axelar adapter receives USDC
-        vm.deal(address(axelarAdapterHarness), dustAmount);
-
-        // switched tokenIn to weth, and tokenOut to usdc - should fail now on swap
-        bytes memory computedRoute = routeProcessorHelper.computeRoute(
-            true,
-            false,
-            address(weth),
-            address(usdc),
-            500,
-            user
-        );
-
-        IRouteProcessor.RouteProcessorData memory rpd = IRouteProcessor
-            .RouteProcessorData({
-                tokenIn: address(weth),
-                amountIn: amount,
-                tokenOut: address(usdc),
-                amountOutMin: 0,
-                to: user,
-                route: computedRoute
-            });
-
-        bytes memory rpd_encoded = abi.encode(rpd);
-
-        bytes memory mockPayload = abi.encode(
-            user, // to
-            rpd_encoded, // _swapData
-            "" // _payloadData
-        );
-
-        axelarAdapterHarness.exposed_executeWithToken{gas: 103384}(
-            "arbitrum",
-            AddressToString.toString(address(axelarAdapter)),
-            mockPayload,
-            "USDC",
-            amount
-        );
-
-        assertEq(
-            usdc.balanceOf(address(axelarAdapterHarness)),
-            0,
-            "axelarAdapter should have 0 usdc"
-        );
-        assertEq(
-            address(axelarAdapterHarness).balance,
-            0,
-            "axelarAdapter should have 0 eth"
-        );
-        assertEq(usdc.balanceOf(user), amount, "user should have all usdc");
-        assertEq(user.balance, dustAmount, "user should have all the dust");
-        assertEq(
-            weth.balanceOf(address(axelarAdapterHarness)),
-            0,
-            "axelarAdapter should have 0 weth"
-        );
-        assertEq(weth.balanceOf(user), 0, "user should have 0 weth");
-    }
-
     function test_ReceiveERC20FailedSwapFromOutOfGas() public {
         uint32 amount = 1000000; // 1 USDC
 

--- a/test/CCTPAdapterTests/CCTPAdapterExecutesTest.sol
+++ b/test/CCTPAdapterTests/CCTPAdapterExecutesTest.sol
@@ -427,68 +427,6 @@ contract CCTPAdapterExecutesTest is BaseTest {
         assertEq(weth.balanceOf(user), 0, "user should have 0 weth");
     }
 
-    function test_ReceiveUSDCAndNativeFailedSwapMinimumGasSent() public {
-        uint32 amount = 1000000; // 1 usdc
-        uint64 dustAmount = 0.2 ether;
-
-        deal(address(usdc), address(cctpAdapterHarness), amount); // cctp adapter receives USDC
-        vm.deal(address(cctpAdapterHarness), dustAmount);
-
-        // switched tokenIn to weth, and tokenOut to usdc - should fail now on swap
-        bytes memory computedRoute = routeProcessorHelper.computeRoute(
-            true,
-            false,
-            address(weth),
-            address(usdc),
-            500,
-            user
-        );
-
-        IRouteProcessor.RouteProcessorData memory rpd = IRouteProcessor
-            .RouteProcessorData({
-                tokenIn: address(weth),
-                amountIn: amount,
-                tokenOut: address(usdc),
-                amountOutMin: 0,
-                to: user,
-                route: computedRoute
-            });
-
-        bytes memory rpd_encoded = abi.encode(rpd);
-
-        bytes memory mockPayload = abi.encode(
-            user, // to
-            amount, // amount of usdc bridged
-            rpd_encoded, // _swapData
-            "" // _payloadData
-        );
-
-        cctpAdapterHarness.exposed_execute{gas: 101570}(
-            "arbitrum",
-            AddressToString.toString(address(cctpAdapter)),
-            mockPayload
-        );
-
-        assertEq(
-            usdc.balanceOf(address(cctpAdapterHarness)),
-            0,
-            "cctp adapter should have 0 usdc"
-        );
-        assertEq(
-            address(cctpAdapterHarness).balance,
-            0,
-            "cctpAdapter should have 0 eth"
-        );
-        assertEq(usdc.balanceOf(user), amount, "user should have all usdc");
-        assertEq(user.balance, dustAmount, "user should have all the dust");
-        assertEq(
-            weth.balanceOf(address(cctpAdapterHarness)),
-            0,
-            "cctp adapter should have 0 weth"
-        );
-        assertEq(weth.balanceOf(user), 0, "user should have 0 weth");
-    }
-
     function test_ReceiveUSDCFailedSwapFromOutOfGas() public {
         uint32 amount = 1000000; // 1 usdc
 

--- a/test/StargateAdapterTests/StargateAdapterReceivesTest.t.sol
+++ b/test/StargateAdapterTests/StargateAdapterReceivesTest.t.sol
@@ -1061,69 +1061,6 @@ contract StargateAdapterReceivesTest is BaseTest {
         assertEq(user.balance, dustAmount, "user should have all the dust");
     }
 
-    function test_ReceiveERC20AndDustFailedSwapMinimumGasSent() public {
-        uint32 amount = 1000001;
-        uint64 dustAmount = 0.2 ether;
-        vm.assume(amount > 1000000); // > 1 usdc
-        vm.assume(dustAmount > 0.1 ether);
-
-        vm.deal(stargateRouter, dustAmount); // dust for sgReceive
-        deal(address(usdc), address(stargateAdapter), amount); // amount adapter receives
-
-        // receive usdc and attempt swap to weth
-        bytes memory computedRoute = routeProcessorHelper.computeRoute(
-            true,
-            false,
-            address(usdc),
-            address(weth),
-            500,
-            user
-        );
-
-        // switched tokenIn to weth, and tokenOut to usdc - should fail now on swap
-        IRouteProcessor.RouteProcessorData memory rpd = IRouteProcessor
-            .RouteProcessorData({
-                tokenIn: address(weth),
-                amountIn: amount,
-                tokenOut: address(usdc),
-                amountOutMin: 0,
-                to: user,
-                route: computedRoute
-            });
-
-        bytes memory rpd_encoded = abi.encode(rpd);
-
-        bytes memory payload = abi.encode(
-            user, // to
-            rpd_encoded, // _swapData
-            "" // _payloadData
-        );
-
-        vm.startPrank(constants.getAddress("mainnet.stargateRouter"));
-        address(stargateAdapter).call{value: dustAmount}("");
-        stargateAdapter.sgReceive{gas: 101570}(
-            0,
-            "",
-            0,
-            address(usdc),
-            amount,
-            payload
-        );
-
-        assertEq(
-            usdc.balanceOf(address(stargateAdapter)),
-            0,
-            "stargateAdapter should have 0 usdc"
-        );
-        assertEq(usdc.balanceOf(user), amount, "user should have all the usdc");
-        assertEq(
-            address(stargateAdapter).balance,
-            0,
-            "stargateAdapter should have 0 eth"
-        );
-        assertEq(user.balance, dustAmount, "user should have all the dust");
-    }
-
     function test_FuzzReceiveNativeFailedSwap(uint64 amount) public {
         vm.assume(amount > 0.1 ether);
 
@@ -1369,7 +1306,9 @@ contract StargateAdapterReceivesTest is BaseTest {
         );
     }
 
-    function test_ReceiveERC20AndSwapToUSDTAndAirdropUSDTFromPayload() public {
+    function test_ReceiveERC20AndSwapToUSDTAndAirdropUSDTFromPayload()
+        public
+    {
         uint32 amount = 1000001;
         vm.assume(amount > 1000000); // > 1 usdc
 
@@ -1704,8 +1643,16 @@ contract StargateAdapterReceivesTest is BaseTest {
             "stargateAdapter should have 0 native"
         );
         assertEq(user.balance, 0, "user should have 0 native");
-        assertGt(user1.balance, 0, "user1 should have > 0 native from airdrop");
-        assertGt(user2.balance, 0, "user2 should have > 0 native from airdrop");
+        assertGt(
+            user1.balance,
+            0,
+            "user1 should have > 0 native from airdrop"
+        );
+        assertGt(
+            user2.balance,
+            0,
+            "user2 should have > 0 native from airdrop"
+        );
     }
 
     function test_ReceiveERC20AndFailedAirdropFromPayload() public {


### PR DESCRIPTION
Reverts sushiswap/sushixswap-v2#13

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on making improvements and optimizations to the SushiXSwapV2 contracts and its adapters.

### Detailed summary:
- Removed the `BridgeOnSource` and `SwapAndBridgeOnSource` events from `ISushiXSwapV2.sol` and `SushiXSwapV2.sol`.
- Updated the `AxelarAdapter.sol`, `StargateAdapter.sol`, and `CCTPAdapter.sol` contracts to use `gasleft()` instead of storing `gasLeft` variable.
- Removed the `test_ReceiveUSDCAndNativeFailedSwapMinimumGasSent` function from `CCTPAdapterTests.sol`.
- Removed the `test_ReceiveUSDCAndNativeFailedSwapMinimumGasSent` function from `AxelarAdapterTests.sol`.
- Removed the `test_ReceiveERC20AndDustFailedSwapMinimumGasSent` function from `StargateAdapterTests.sol`.
- Removed the `test_ReceiveERC20AndSwapToUSDTAndAirdropUSDTFromPayload` and `test_ReceiveERC20AndFailedAirdropFromPayload` functions from `StargateAdapterReceivesTest.sol`.

Note: The PR includes other changes that are not mentioned here, such as imports and negligible modifications.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->