### PR TITLE
fix: safeTransfer amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://etherscan.io/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://etherscan.io/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0x580ED43F3BBa06555785C81c2957efCCa71f7483](https://etherscan.io/address/0x580ED43F3BBa06555785C81c2957efCCa71f7483)
 </td><td>
 
 [0x02a480a258361c9bc3eaacbd6473364c67adcd3a](https://etherscan.io/address/0x02a480a258361c9bc3eaacbd6473364c67adcd3a)
@@ -59,7 +59,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://bscscan.com/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://bscscan.com/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0x078047150F8efa223B3d407f00E462e38f4B1b9C](https://bscscan.com/address/0x078047150F8efa223B3d407f00E462e38f4B1b9C)
 </td><td>
 
 [0x02a480a258361c9bc3eaacbd6473364c67adcd3a](https://bscscan.com/address/0x02a480a258361c9bc3eaacbd6473364c67adcd3a)
@@ -71,7 +71,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://snowtrace.io/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://snowtrace.io/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0x078047150F8efa223B3d407f00E462e38f4B1b9C](https://snowtrace.io/address/0x078047150F8efa223B3d407f00E462e38f4B1b9C)
 </td><td>
 
 [0x02a480a258361c9bc3eaacbd6473364c67adcd3a](https://snowtrace.io/address/0x02a480a258361c9bc3eaacbd6473364c67adcd3a)
@@ -83,7 +83,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://polygonscan.com/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x02a480a258361c9Bc3eaacBd6473364C67adCD3a](https://polygonscan.com/address/0x02a480a258361c9Bc3eaacBd6473364C67adCD3a)
+[0x5AbEdAc449A8301467c3e124B98e7151641F1e56](https://polygonscan.com/address/0x5AbEdAc449A8301467c3e124B98e7151641F1e56)
 </td><td>
 
 [0x01f27998B1fc39b5280BcBe2a24043f9dbDFc305](https://polygonscan.com/address/0x01f27998B1fc39b5280BcBe2a24043f9dbDFc305)
@@ -95,7 +95,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://arbiscan.io/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://arbiscan.io/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0xFbc12984689e5f15626Bad03Ad60160Fe98B303C](https://arbiscan.io/address/0xFbc12984689e5f15626Bad03Ad60160Fe98B303C)
 </td><td>
 
 [0x02a480a258361c9bc3eaacbd6473364c67adcd3a](https://arbiscan.io/address/0x02a480a258361c9bc3eaacbd6473364c67adcd3a)
@@ -107,7 +107,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://optimistic.etherscan.io/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://optimistic.etherscan.io/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0x078047150F8efa223B3d407f00E462e38f4B1b9C](https://optimistic.etherscan.io/address/0x078047150F8efa223B3d407f00E462e38f4B1b9C)
 </td><td>
 
 [0x02a480a258361c9bc3eaacbd6473364c67adcd3a](https://optimistic.etherscan.io/address/0x02a480a258361c9bc3eaacbd6473364c67adcd3a)
@@ -119,7 +119,7 @@ make test
 [0x804b526e5bf4349819fe2db65349d0825870f8ee](https://basescan.org/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://basescan.org/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0x580ED43F3BBa06555785C81c2957efCCa71f7483](https://basescan.org/address/0x580ED43F3BBa06555785C81c2957efCCa71f7483)
 </td><td>
 
 [0x02a480a258361c9bc3eaacbd6473364c67adcd3a](https://basescan.org/address/0x02a480a258361c9bc3eaacbd6473364c67adcd3a)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ make test
 [0x804b526e5bF4349819fe2Db65349d0825870F8Ee](https://ftmscan.com/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716C4a086a4ebfE10377Fdad96F32541303](https://ftmscan.com/address/0x09938716C4a086a4ebfE10377Fdad96F32541303)
+[0xFbc12984689e5f15626Bad03Ad60160Fe98B303C](https://ftmscan.com/address/0xFbc12984689e5f15626Bad03Ad60160Fe98B303C)
 </td><td>
 
 [0x02a480a258361c9Bc3eaacBd6473364C67adCD3a](https://ftmscan.com/address/0x02a480a258361c9Bc3eaacBd6473364C67adCD3a)
@@ -143,7 +143,7 @@ make test
 [0x804b526e5bF4349819fe2Db65349d0825870F8Ee](https://lineascan.build/address/0x804b526e5bf4349819fe2db65349d0825870f8ee)
 </td><td>
 
-[0x09938716c4a086a4ebfe10377fdad96f32541303](https://lineascan.build/address/0x09938716c4a086a4ebfe10377fdad96f32541303)
+[0x078047150F8efa223B3d407f00E462e38f4B1b9C](https://lineascan.build/address/0x078047150F8efa223B3d407f00E462e38f4B1b9C)
 </td><td>
 
 [0x01f27998B1fc39b5280BcBe2a24043f9dbDFc305](https://lineascan.build/address/0x01f27998b1fc39b5280bcbe2a24043f9dbdfc305)
@@ -155,7 +155,7 @@ make test
 [0xD5607d184b1D6ecbA94A07c217497FE9346010D9](https://kavascan.com/address/0xD5607d184b1D6ecbA94A07c217497FE9346010D9)
 </td><td>
 
-[0x90dAB18856331a85dC64203cE39AAb01447dC134](https://kavascan.com/address/0x90dAB18856331a85dC64203cE39AAb01447dC134)
+[0x3E30436a8694B22C5c90c51bb05cA24cdf52cB71](https://kavascan.com/address/0x3E30436a8694B22C5c90c51bb05cA24cdf52cB71)
 </td><td>
 
 [0x630BE2985674D31920BAbb4F96657960F131E7b1](https://kavascan.com/address/0x630BE2985674D31920BAbb4F96657960F131E7b1)
@@ -167,7 +167,7 @@ make test
 [0x804b526e5bF4349819fe2Db65349d0825870F8Ee](https://andromeda-explorer.metis.io/address/0x804b526e5bF4349819fe2Db65349d0825870F8Ee)
 </td><td>
 
-[0x09938716C4a086a4ebfE10377Fdad96F32541303](https://andromeda-explorer.metis.io/address/0x09938716C4a086a4ebfE10377Fdad96F32541303)
+[0xFF51a7C624Eb866917102707F3dA8bFb99Db8692](https://andromeda-explorer.metis.io/address/0xFF51a7C624Eb866917102707F3dA8bFb99Db8692)
 </td><td>
 </td></tr>
 </table>

--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -198,7 +198,7 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         }
 
         if (IERC20(_token).balanceOf(address(this)) > 0)
-            IERC20(_token).safeTransfer(to, amount);
+            IERC20(_token).safeTransfer(to, IERC20(_token).balanceOf(address(this)));
 
         /// @dev transfer any native token received as dust to the to address
         if (address(this).balance > 0)

--- a/src/adapters/CCTPAdapter.sol
+++ b/src/adapters/CCTPAdapter.sol
@@ -213,7 +213,7 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         }
 
         if (nativeUSDC.balanceOf(address(this)) > 0)
-            nativeUSDC.safeTransfer(to, amount);
+            nativeUSDC.safeTransfer(to, nativeUSDC.balanceOf(address(this)));
 
         /// @dev transfer any native token received as dust to the to address
         if (address(this).balance > 0)

--- a/src/adapters/StargateAdapter.sol
+++ b/src/adapters/StargateAdapter.sol
@@ -251,7 +251,7 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         } else {}
 
         if (IERC20(_token).balanceOf(address(this)) > 0 && _token != sgeth)
-            IERC20(_token).safeTransfer(to, amountLD);
+            IERC20(_token).safeTransfer(to, IERC20(_token).balanceOf(address(this)));
 
         /// @dev transfer any native token received as dust to the to address
         if (address(this).balance > 0)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on transferring any native token received as dust to the specified address. 

### Detailed summary
- Updated the transfer function in `CCTPAdapter.sol` to transfer the entire balance of `nativeUSDC` token to the specified address.
- Updated the transfer function in `AxelarAdapter.sol` to transfer the entire balance of the specified token to the specified address.
- Updated the transfer function in `StargateAdapter.sol` to transfer the entire balance of the specified token to the specified address, except if the token is `sgeth`.
- Updated the README.md file with new contract addresses for different networks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->