### PR TITLE
reset approvals after adapterBridge on adapters, in case of truncatio…

### DIFF
--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -143,6 +143,9 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
             Bytes32ToString.toTrimmedString(params.symbol),
             params.amount
         );
+
+        // reset approval
+        IERC20(params.token).safeApprove(address(gateway), 0);
     }
 
     /// @notice Receiver function on dst chain

--- a/src/adapters/CCTPAdapter.sol
+++ b/src/adapters/CCTPAdapter.sol
@@ -160,6 +160,9 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
             AddressToString.toString(params.destinationAddress),
             payload
         );
+
+        // reset approval
+        nativeUSDC.safeApprove(address(tokenMessenger), 0);
     }
 
     /// @notice Receiver function on dst chain

--- a/src/adapters/StargateAdapter.sol
+++ b/src/adapters/StargateAdapter.sol
@@ -194,6 +194,13 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         );
 
         stargateWidget.partnerSwap(0x0001);
+
+        // reset approval since amounts can truncate sometimes
+        if (params.token != NATIVE_ADDRESS)
+            IERC20(params.token).safeApprove(
+                address(stargateComposer),
+                0
+            );
     }
 
     /// @notice Receiver function on dst chain
@@ -209,7 +216,8 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         bytes memory payload
     ) external {
         uint256 gasLeft = gasleft();
-        if (msg.sender != address(stargateComposer)) revert NotStargateComposer();
+        if (msg.sender != address(stargateComposer))
+            revert NotStargateComposer();
 
         (address to, bytes memory _swapData, bytes memory _payloadData) = abi
             .decode(payload, (address, bytes, bytes));
@@ -251,7 +259,10 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         } else {}
 
         if (IERC20(_token).balanceOf(address(this)) > 0 && _token != sgeth)
-            IERC20(_token).safeTransfer(to, IERC20(_token).balanceOf(address(this)));
+            IERC20(_token).safeTransfer(
+                to,
+                IERC20(_token).balanceOf(address(this))
+            );
 
         /// @dev transfer any native token received as dust to the to address
         if (address(this).balance > 0)

--- a/test/StargateAdapterTests/StargateAdapterReceivesTest.t.sol
+++ b/test/StargateAdapterTests/StargateAdapterReceivesTest.t.sol
@@ -163,7 +163,7 @@ contract StargateAdapterReceivesTest is BaseTest {
     }
 
     function test_FuzzReceiveExtraERC20AndSwapToERC20UserReceivesExtra(uint32 amount) public {
-        vm.assume(amount > 1000000); // > 1 usdc
+        vm.assume(amount > 1000000 && amount < type(uint32).max); // > 1 usdc
 
         deal(address(usdc), address(stargateAdapter), amount + 1); // amount adapter receives
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on resetting approvals and making some improvements in the code.

### Detailed summary:
- In `CCTPAdapter.sol`, the approval for `nativeUSDC` is reset.
- In `AxelarAdapter.sol`, the approval for `params.token` is reset.
- In `StargateAdapterTests/StargateAdapterReceivesTest.t.sol`, the assumption for `amount` is modified.
- In `StargateAdapter.sol`, the approval for `params.token` is reset.
- Some code formatting improvements are made in `StargateAdapter.sol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->