### PR TITLE
chore: replace safeApprove with forceApprove

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,10 +5,10 @@
 [submodule "lib/forge-gas-snapshot"]
 	path = lib/forge-gas-snapshot
 	url = https://github.com/marktoda/forge-gas-snapshot
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/openzeppelin/openzeppelin-contracts
-	branch = v4.8.2
 [submodule "lib/axelar-gmp-sdk-solidity"]
 	path = lib/axelar-gmp-sdk-solidity
 	url = https://github.com/axelarnetwork/axelar-gmp-sdk-solidity
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+	branch = v4.9.0

--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -117,7 +117,7 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
         if (params.amount == 0)
             params.amount = IERC20(params.token).balanceOf(address(this));
 
-        IERC20(params.token).safeApprove(address(gateway), params.amount);
+        IERC20(params.token).forceApprove(address(gateway), params.amount);
 
         // build payload from _swapData and _payloadData
         bytes memory payload = abi.encode(params.to, _swapData, _payloadData);
@@ -143,9 +143,6 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
             Bytes32ToString.toTrimmedString(params.symbol),
             params.amount
         );
-
-        // reset approval
-        IERC20(params.token).safeApprove(address(gateway), 0);
     }
 
     /// @notice Receiver function on dst chain

--- a/src/adapters/CCTPAdapter.sol
+++ b/src/adapters/CCTPAdapter.sol
@@ -124,7 +124,7 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
             params.amount = nativeUSDC.balanceOf(address(this));
 
         // burn params.amount of USDC tokens
-        nativeUSDC.safeApprove(address(tokenMessenger), params.amount);
+        nativeUSDC.forceApprove(address(tokenMessenger), params.amount);
 
         tokenMessenger.depositForBurn(
             params.amount,
@@ -160,9 +160,6 @@ contract CCTPAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
             AddressToString.toString(params.destinationAddress),
             payload
         );
-
-        // reset approval
-        nativeUSDC.safeApprove(address(tokenMessenger), 0);
     }
 
     /// @notice Receiver function on dst chain

--- a/src/adapters/SquidAdapter.sol
+++ b/src/adapters/SquidAdapter.sol
@@ -48,7 +48,7 @@ contract SquidAdapter is ISushiXSwapV2Adapter {
         );
 
         if (token != NATIVE_ADDRESS) {
-            IERC20(token).safeApprove(
+            IERC20(token).forceApprove(
                 squidRouter,
                 IERC20(token).balanceOf(address(this))
             );

--- a/src/adapters/StargateAdapter.sol
+++ b/src/adapters/StargateAdapter.sol
@@ -164,7 +164,7 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
             if (params.amount == 0)
                 params.amount = IERC20(params.token).balanceOf(address(this));
 
-            IERC20(params.token).safeApprove(
+            IERC20(params.token).forceApprove(
                 address(stargateComposer),
                 params.amount
             );
@@ -194,13 +194,6 @@ contract StargateAdapter is ISushiXSwapV2Adapter, IStargateReceiver {
         );
 
         stargateWidget.partnerSwap(0x0001);
-
-        // reset approval since amounts can truncate sometimes
-        if (params.token != NATIVE_ADDRESS)
-            IERC20(params.token).safeApprove(
-                address(stargateComposer),
-                0
-            );
     }
 
     /// @notice Receiver function on dst chain

--- a/test/StargateAdapterTests/StargateAdapterBridgeTest.t.sol
+++ b/test/StargateAdapterTests/StargateAdapterBridgeTest.t.sol
@@ -219,7 +219,7 @@ contract StargateAdapterBridgeTest is BaseTest {
 
         // basic usdc bridge
         vm.startPrank(user);
-        usdt.safeApprove(address(sushiXswap), amount);
+        usdt.forceApprove(address(sushiXswap), amount);
 
         (uint256 gasNeeded, ) = stargateAdapter.getFee(
             110, // dstChainId
@@ -232,8 +232,8 @@ contract StargateAdapterBridgeTest is BaseTest {
 
         (, uint256 eqFee, , , uint256 protocolFee, ) = stargateFeeLibrary
             .getFees(
-                1, // srcPoolId
-                1, // dstPoolId
+                2, // srcPoolId
+                2, // dstPoolId
                 110, // dstChainId
                 address(stargateAdapter), // from
                 amount // amountSD


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The PR updates the `safeApprove` function calls to `forceApprove` in multiple files.
- The PR also updates the submodule URL for `lib/openzeppelin-contracts` to a different repository and branch.
- Some minor changes to the test files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->