### PR TITLE
fix: replace `string memory` => `string calldata` in _executeWithToken in AxelarAdapter

### DIFF
--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -155,10 +155,10 @@ contract AxelarAdapter is ISushiXSwapV2Adapter, AxelarExecutable {
     /// @param tokenSymbol bridged token symbol
     /// @param amount bridged token amount
     function _executeWithToken(
-        string memory sourceChain,
-        string memory sourceAddress,
+        string calldata sourceChain,
+        string calldata sourceAddress,
         bytes calldata payload,
-        string memory tokenSymbol,
+        string calldata tokenSymbol,
         uint256 amount
     ) internal override {
         uint256 gasLeft = gasleft();

--- a/test/AxelarAdapterTests/AxelarAdapterExecutesTest.t.sol
+++ b/test/AxelarAdapterTests/AxelarAdapterExecutesTest.t.sol
@@ -24,10 +24,10 @@ contract AxelarAdapterHarness is AxelarAdapter {
     ) AxelarAdapter(_axelarGateway, _gasService, _rp, _weth) {}
 
     function exposed_executeWithToken(
-        string memory sourceChain,
-        string memory sourceAddress,
+        string calldata sourceChain,
+        string calldata sourceAddress,
         bytes calldata payload,
-        string memory tokenSymbol,
+        string calldata tokenSymbol,
         uint256 amount
     ) external {
         _executeWithToken(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating function parameters from `memory` to `calldata` in the `exposed_executeWithToken` and `_executeWithToken` functions in the `AxelarAdapterExecutesTest.t.sol` and `AxelarAdapter.sol` files.

### Detailed summary
- Updated function parameters from `memory` to `calldata` in `exposed_executeWithToken` function in `AxelarAdapterExecutesTest.t.sol`.
- Updated function parameters from `memory` to `calldata` in `_executeWithToken` function in `AxelarAdapter.sol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->